### PR TITLE
feat: ready 事件返回总页数

### DIFF
--- a/js/pdfh5.js
+++ b/js/pdfh5.js
@@ -1544,7 +1544,7 @@
 					var arr1 = self.eventType["ready"];
 					if (arr1 && arr1 instanceof Array) {
 						for (var i = 0; i < arr1.length; i++) {
-							arr1[i] && arr1[i].call(self);
+							arr1[i] && arr1[i].call(self, self.totalNum);
 						}
 					}
 					self.pinchZoom = new PinchZoom(self.viewer, {


### PR DESCRIPTION
原来 ready 事件没有在回调中返回 totalNum，导致外面不能直接取 this.totalNum, 所以在 ready 事件中返回该结果