### PR TITLE
feat: 添加对 pdfjs@2.11.338 版本的 textLayer支持

### DIFF
--- a/css/pdfh5.css
+++ b/css/pdfh5.css
@@ -39,7 +39,7 @@
     height: 100%;
     position: relative;
     z-index: 100;
-	/* user-select:none; */
+    user-select:none;
 }
 
 .pdfjs .pageNum {
@@ -157,6 +157,11 @@
   opacity: 0.2;
   line-height: 1.0;
   z-index: 101;
+  user-select: text;
+}
+
+.pdfjs .textLayer > br::selection {
+  background-color: transparent !important;
 }
 
 .pdfjs .textLayer > span {
@@ -165,7 +170,6 @@
   white-space: pre;
   cursor: text;
   transform-origin: 0% 0%;
-  transform: translate(-99px, -80px) scaleX(1) !important;
 }
 
 .pdfjs .textLayer .highlight {

--- a/pdf.html
+++ b/pdf.html
@@ -77,7 +77,6 @@
 	<script src="js/jquery-3.6.0.min.js" type="text/javascript" charset="utf-8"></script>
 	<script src="js/pdfh5.js" type="text/javascript" charset="utf-8"></script>
 	<script src="./vconsole.min.js"></script>
-	<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 	<script type="text/javascript">
 		var vConsole = new VConsole();
 		console.log('Hello world');
@@ -86,6 +85,7 @@
 		$("#demo").show();
 		pdfh5 = new Pdfh5('#demo', {
 			pdfurl: "git.pdf",
+			textLayer: true,
 			// renderType: "svg",
 			// cMapUrl:"https://unpkg.com/pdfjs-dist@2.7.570/cmaps/",
 			// responseType: "blob" // blob arraybuffer


### PR DESCRIPTION
添加了对 pdf 预览的 textlayer的支持。
并添加了对页面resize时的，重新计算尺寸的逻辑
![image](https://github.com/user-attachments/assets/15054abc-4408-417f-8fa8-248320f4adf9)
