### PR TITLE
增加防xss注入支持

### DIFF
--- a/js/pdfh5.js
+++ b/js/pdfh5.js
@@ -1616,6 +1616,9 @@
 			if (options.disableAutoFetch) {
 				obj.disableAutoFetch = true;
 			}
+			if (options.disableEvalSupported) {
+				obj.isEvalSupported = false;
+			}
 			obj.cMapPacked = true;
 			obj.rangeChunkSize = 65536;
 			this.pdfjsLibPromise = pdfjsLib.getDocument(obj).promise.then(function (pdf) {


### PR DESCRIPTION
增加page.js的配置选项， isEvalSupported: false
作用：禁用 PDF 中的 JavaScript（包括计算表达式、事件处理器、按钮脚本等）。